### PR TITLE
Fixes #26: use apps/v1 as apiVersion Deployment

### DIFF
--- a/templates/kubernetes/deployment.yaml
+++ b/templates/kubernetes/deployment.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rocketmq
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: rocketmq
   template:
     metadata:
      labels:

--- a/templates/kubernetes/deployment2.yaml
+++ b/templates/kubernetes/deployment2.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: rocketmq-ns-deployment
 spec:
@@ -31,7 +31,7 @@ spec:
         emptyDir: {}
 ---          
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: rocketmq-broker-deployment
 spec:


### PR DESCRIPTION
Use apps/v1 for deployment. Latest k8s versions donot support extenstion/v1beta1