### PR TITLE
fix namesrv

### DIFF
--- a/product/start-dashboard.sh
+++ b/product/start-dashboard.sh
@@ -17,4 +17,4 @@
 
 ROCKETMQ_DASHBOARD_VERSION=$1
 
-docker run -d -it --name rocketmq-dashboard -p 6765:8080 apache/rocketmq-dashboard:${ROCKETMQ_DASHBOARD_VERSION}-centos
+docker run -d -it --name rocketmq-dashboard -p 6765:8080 --link rmqnamesrv:namesrv apache/rocketmq-dashboard:${ROCKETMQ_DASHBOARD_VERSION}-centos --rocketmq.config.namesrvAddr=namesrv:9876


### PR DESCRIPTION
Caused by: org.apache.rocketmq.remoting.exception.RemotingConnectException: connect to null failed

Fix the problem that dashboard cannot connect to namesrv