### PR TITLE
[ISSUE #74]add entry point for docker (alpine)

### DIFF
--- a/image-build/Dockerfile-alpine
+++ b/image-build/Dockerfile-alpine
@@ -15,20 +15,38 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-alpine
+################################################################################
+# Build stage 1 `builder`:
+# Download and extract RocketMQ
+################################################################################
+FROM eclipse-temurin:8-jdk-alpine AS builder
 
-RUN apk add --no-cache bash gettext nmap-ncat openssl busybox-extras
+ARG version
+
+RUN set -eux; \
+    apk add --virtual .build-deps curl gnupg unzip;
+
+RUN curl -L https://archive.apache.org/dist/rocketmq/${version}/rocketmq-all-${version}-bin-release.zip -o rocketmq.zip; \
+    curl -L https://archive.apache.org/dist/rocketmq/${version}/rocketmq-all-${version}-bin-release.zip.asc -o rocketmq.zip.asc; \
+	curl -L https://www.apache.org/dist/rocketmq/KEYS -o KEYS; \
+	gpg --import KEYS; \
+    gpg --batch --verify rocketmq.zip.asc rocketmq.zip;
+
+RUN unzip rocketmq.zip; \
+    mkdir -p /tmp/rocketmq-${version}; \
+	mv rocketmq*/* /tmp/rocketmq-${version}
+
+   
+################################################################################
+# Build stage 2:
+# Make the actual RocketMQ docker image
+################################################################################
+FROM eclipse-temurin:8-jdk-alpine
 
 ARG user=rocketmq
 ARG group=rocketmq
 ARG uid=3000
 ARG gid=3000
-
-# RocketMQ is run with user `rocketmq`, uid = 3000
-# If you bind mount a volume from the host or a data container,
-# ensure you use the same uid
-RUN addgroup --gid ${gid} ${group} \
-    && adduser --uid ${uid} -G ${group} ${user} -s /bin/bash -D
 
 ARG version
 
@@ -38,53 +56,42 @@ ENV ROCKETMQ_VERSION ${version}
 # Rocketmq home
 ENV ROCKETMQ_HOME  /home/rocketmq/rocketmq-${ROCKETMQ_VERSION}
 
-WORKDIR  ${ROCKETMQ_HOME}
 
-# Install
-RUN set -eux; \
-    apk add --virtual .build-deps curl gnupg unzip; \
-    curl -L https://archive.apache.org/dist/rocketmq/${ROCKETMQ_VERSION}/rocketmq-all-${ROCKETMQ_VERSION}-bin-release.zip -o rocketmq.zip; \
-    curl -L https://archive.apache.org/dist/rocketmq/${ROCKETMQ_VERSION}/rocketmq-all-${ROCKETMQ_VERSION}-bin-release.zip.asc -o rocketmq.zip.asc; \
-    #https://www.apache.org/dist/rocketmq/KEYS
-	curl -L https://www.apache.org/dist/rocketmq/KEYS -o KEYS; \
-	\
-	gpg --import KEYS; \
-    gpg --batch --verify rocketmq.zip.asc rocketmq.zip; \
-    unzip rocketmq.zip; \
-	mv rocketmq*/* . ; \
-	rmdir rocketmq-* ; \
-	rm rocketmq.zip rocketmq.zip.asc KEYS; \
-	apk del .build-deps ; \
-    rm -rf /var/cache/apk/* ; \
-    rm -rf /tmp/*
+# Expose namesrv port
+EXPOSE 9876
+# Expose broker ports
+EXPOSE 10909 10911 10912
+
+# RocketMQ is run with user `rocketmq`, uid = 3000
+# If you bind mount a volume from the host or a data container,
+# ensure you use the same uid
+RUN addgroup --gid ${gid} ${group} \
+    && adduser --uid ${uid} -G ${group} ${user} -s /bin/bash -D \
+    && apk add --no-cache bash gettext nmap-ncat openssl busybox-extras
 
 # Copy customized scripts
 COPY scripts/ ${ROCKETMQ_HOME}/bin/
 
-RUN chown -R ${uid}:${gid} ${ROCKETMQ_HOME}
+# Copy RocketMQ artifact from builder
+COPY --from=builder --chown=${uid}:${gid} /tmp/rocketmq-${version}/ ${ROCKETMQ_HOME}
 
-# Expose namesrv port
-EXPOSE 9876
 
 # Override customized scripts for namesrv
-RUN mv ${ROCKETMQ_HOME}/bin/runserver-customize.sh ${ROCKETMQ_HOME}/bin/runserver.sh \
- && chmod a+x ${ROCKETMQ_HOME}/bin/runserver.sh \
- && chmod a+x ${ROCKETMQ_HOME}/bin/mqnamesrv
-
-# Expose broker ports
-EXPOSE 10909 10911 10912
-
 # Override customized scripts for broker
-RUN mv ${ROCKETMQ_HOME}/bin/runbroker-customize.sh ${ROCKETMQ_HOME}/bin/runbroker.sh \
- && chmod a+x ${ROCKETMQ_HOME}/bin/runbroker.sh \
- && chmod a+x ${ROCKETMQ_HOME}/bin/mqbroker
-
 # Export Java options
-RUN export JAVA_OPT=" -Duser.home=/opt"
-
 # Add ${JAVA_HOME}/lib/ext as java.ext.dirs
-RUN sed -i 's/${JAVA_HOME}\/jre\/lib\/ext/${JAVA_HOME}\/jre\/lib\/ext:${JAVA_HOME}\/lib\/ext/' ${ROCKETMQ_HOME}/bin/tools.sh
+RUN mv ${ROCKETMQ_HOME}/bin/runserver-customize.sh ${ROCKETMQ_HOME}/bin/runserver.sh \
+ && mv ${ROCKETMQ_HOME}/bin/runbroker-customize.sh ${ROCKETMQ_HOME}/bin/runbroker.sh \
+ && chmod -R a+x ${ROCKETMQ_HOME}/bin/ \
+ && export JAVA_OPT=" -Duser.home=/opt" \
+ && sed -i 's/${JAVA_HOME}\/jre\/lib\/ext/${JAVA_HOME}\/jre\/lib\/ext:${JAVA_HOME}\/lib\/ext/' ${ROCKETMQ_HOME}/bin/tools.sh \
+ && chown -R ${uid}:${gid} ${ROCKETMQ_HOME}
 
 USER ${user}
 
 WORKDIR ${ROCKETMQ_HOME}/bin
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
+# Dummy overridable parameter parsed by entrypoint
+CMD ["dummy"]
+

--- a/image-build/scripts/docker-entrypoint.sh
+++ b/image-build/scripts/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# Allow user specify custom CMD, maybe run /bin/bash to check the image
+if [[ "$1" == "nameserver" || "${NODE_ROLE}" == "nameserver" ]]; then
+  shift
+  exec ./mqnamesrv "${@}"
+elif [[ "$1" == "broker" || "${NODE_ROLE}" == "broker" ]]; then
+  shift
+  exec ./mqbroker "${@}"
+elif [[ "$1" == "controller" || "${NODE_ROLE}" == "controller" ]]; then
+  shift
+  exec ./mqcontroller "${@}"
+else
+  # Run whatever command the user wants
+  exec "$@"
+fi


### PR DESCRIPTION
**Which Issue(s) This PR Fixes**
Fix #74 

**Brief Description**

- Add an entry-point script in Dockerfile-alpine.
- Separate the downloading process from the main docker, which helps decease the image size and the build time (especially resuming from previous failed builds).
- Replace the base image `openjdk:8-alpine` with `eclipse-temurin:8-jdk-alpine`, as the former has been deprecated: https://hub.docker.com/_/openjdk.