### PR TITLE
[ISSUE #108] Replace centos base image with ubuntu for centos7 is EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd image-build
 sh build-image.sh RMQ-VERSION BASE-IMAGE
 ```
 
-> Tip: The supported RMQ-VERSIONs can be obtained from [here](https://archive.apache.org/dist/rocketmq/). The supported BASE-IMAGEs are [centos, alpine]. For example: ```sh build-image.sh 4.5.0 alpine```
+> Tip: The supported RMQ-VERSIONs can be obtained from [here](https://archive.apache.org/dist/rocketmq/). The supported BASE-IMAGEs are [ubuntu, alpine]. For example: ```sh build-image.sh 4.5.0 alpine```
 
 ### B. Stage a specific version
 
@@ -134,7 +134,7 @@ cd image-build
 ./update.sh 
 ```
 
-This script will get the latest release version of RocketMQ and build the docker images based on ```alpine``` and ```centos``` respectively, then push the new images to the current official repository ```apache/rocketmq```.
+This script will get the latest release version of RocketMQ and build the docker images based on ```alpine``` and ```ubuntu``` respectively, then push the new images to the current official repository ```apache/rocketmq```.
 
 ### How to verify RocketMQ works well
 

--- a/image-build/Dockerfile-ubuntu
+++ b/image-build/Dockerfile-ubuntu
@@ -19,14 +19,17 @@
 # Build stage 1 `builder`:
 # Download and extract RocketMQ
 ################################################################################
-FROM eclipse-temurin:8-jdk-centos7 AS builder
+FROM eclipse-temurin:8-jdk AS builder
 
 ARG version
 
-RUN set -eux \
-    && yum -y update \
-    && yum -y install curl gnupg unzip \
-    && yum clean all -y
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        gnupg2 \
+        unzip \
+    ; \
+    rm -rf /var/lib/apt/lists/*
 
 RUN curl -L https://archive.apache.org/dist/rocketmq/${version}/rocketmq-all-${version}-bin-release.zip -o rocketmq.zip \
     && curl -L https://archive.apache.org/dist/rocketmq/${version}/rocketmq-all-${version}-bin-release.zip.asc -o rocketmq.zip.asc \
@@ -42,7 +45,7 @@ RUN unzip rocketmq.zip \
 # Build stage 2:
 # Make the actual RocketMQ docker image
 ################################################################################
-FROM eclipse-temurin:8-jdk-centos7
+FROM eclipse-temurin:8-jdk
 
 ARG user=rocketmq
 ARG group=rocketmq
@@ -52,10 +55,10 @@ ARG gid=3000
 ARG version
 
 # Rocketmq version
-ENV ROCKETMQ_VERSION ${version}
+ENV ROCKETMQ_VERSION=${version}
 
 # Rocketmq home
-ENV ROCKETMQ_HOME  /home/rocketmq/rocketmq-${ROCKETMQ_VERSION}
+ENV ROCKETMQ_HOME=/home/rocketmq/rocketmq-${ROCKETMQ_VERSION}
 
 # expose namesrv port
 EXPOSE 9876
@@ -68,11 +71,14 @@ EXPOSE 10909 10911 10912
 # ensure you use the same uid
 RUN groupadd -g ${gid} ${group} \
     && useradd -l -u ${uid} -g ${gid} -m -s /bin/bash ${user} \
-    && yum -y update \
-    && yum -y install less openssl which \
-    && yum clean all -y && rm -rf /var/cache/yum 
-
-
+    && apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        less \
+        openssl \
+        which \
+    \
+    && apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy customized scripts
 COPY scripts/ ${ROCKETMQ_HOME}/bin/

--- a/image-build/build-image.sh
+++ b/image-build/build-image.sh
@@ -41,11 +41,11 @@ case "${BASE_IMAGE}" in
     alpine)
         docker build --no-cache -f Dockerfile-alpine -t apache/rocketmq:${ROCKETMQ_VERSION}-alpine --build-arg version=${ROCKETMQ_VERSION} .
     ;;
-    centos)
-        docker build --no-cache -f Dockerfile-centos -t apache/rocketmq:${ROCKETMQ_VERSION} --build-arg version=${ROCKETMQ_VERSION} .
+    ubuntu)
+        docker build --no-cache -f Dockerfile-ubuntu -t apache/rocketmq:${ROCKETMQ_VERSION} --build-arg version=${ROCKETMQ_VERSION} .
     ;;
     *)
-        echo "${BASE_IMAGE} is not supported, supported base images: centos, alpine"
+        echo "${BASE_IMAGE} is not supported, supported base images: ubuntu, alpine"
         exit -1
     ;;
 esac

--- a/image-build/update.sh
+++ b/image-build/update.sh
@@ -34,13 +34,13 @@ LATEST_VERSION=$(curl -s https://archive.apache.org/dist/rocketmq/ | awk -F '>' 
 
 checkVersion ${LATEST_VERSION}
 
-baseImages=("alpine" "centos")
+baseImages=("alpine" "ubuntu")
 
 for baseImage in ${baseImages[@]}
 do
     echo "Building image of version ${LATEST_VERSION}, base-image ${baseImage}"
     bash build-image.sh ${LATEST_VERSION} ${baseImage}
-    if [ "${baseImage}" = "centos" ];then
+    if [ "${baseImage}" = "ubuntu" ];then
         TAG=${LATEST_VERSION}
     else
         TAG=${LATEST_VERSION}-${baseImage}

--- a/product/README.md
+++ b/product/README.md
@@ -35,7 +35,7 @@ How to config a 2m-2s-async cluster in Docker style.
 
 Note: You can skip this step if you use an existing nameserver cluster
 
-1. Confirm the host machine where the nameserver is to be deployed and copy the product directory into the host. Determine the directory (DATA_HOME) where the container persistences content (logs/storage) on the host,  as well as the RocketMQ image version (ROCKETMQ_VERSION) and base image alpine or centos (BASE_IMAGE)
+1. Confirm the host machine where the nameserver is to be deployed and copy the product directory into the host. Determine the directory (DATA_HOME) where the container persistences content (logs/storage) on the host,  as well as the RocketMQ image version (ROCKETMQ_VERSION) and base image alpine or ubuntu (BASE_IMAGE)
 
 2. Run the script start-ns.sh, for example:
 

--- a/product/start-broker.sh
+++ b/product/start-broker.sh
@@ -57,11 +57,11 @@ case "${BASE_IMAGE}" in
     alpine)
         start_broker -alpine
     ;;
-    centos)
+    ubuntu|centos)
         start_broker
     ;;
     *)
-        echo "${BASE_IMAGE} is not supported, supported base images: centos, alpine"
+        echo "${BASE_IMAGE} is not supported, supported base images: ubuntu, alpine, centos (deprecated)"
         exit -1
     ;;
 esac

--- a/product/start-ns.sh
+++ b/product/start-ns.sh
@@ -45,11 +45,11 @@ case "${BASE_IMAGE}" in
     alpine)
         start_namesrv -alpine
     ;;
-    centos)
+    ubuntu|centos)
         start_namesrv
     ;;
     *)
-        echo "${BASE_IMAGE} is not supported, supported base images: centos, alpine"
+        echo "${BASE_IMAGE} is not supported, supported base images: ubuntu, alpine, centos (deprecated)"
         exit -1
     ;;
 esac

--- a/templates/play-docker.sh
+++ b/templates/play-docker.sh
@@ -62,11 +62,11 @@ case "${BASE_IMAGE}" in
     alpine)
         start_namesrv_broker -alpine
     ;;
-    centos)
+    ubuntu|centos)
         start_namesrv_broker
     ;;
     *)
-        echo "${BASE_IMAGE} is not supported, supported base images: centos, alpine"
+        echo "${BASE_IMAGE} is not supported, supported base images: ubuntu, alpine, centos (deprecated)"
         exit -1
     ;;
 esac


### PR DESCRIPTION
fix #108 

As CentOS 7 has reached EOL, use the official default Temurin JDK image, which is based on Ubuntu, as the base image for docker image of Apache RocketMQ. The original docker image based on CentOS 7 will be deprecated.