### PR TITLE
Allow custom JVM memory via environment variables

### DIFF
--- a/image-build-ci/Dockerfile-ubuntu
+++ b/image-build-ci/Dockerfile-ubuntu
@@ -21,7 +21,7 @@ FROM $BASE_IMAGE
 USER root
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		bash vim unzip telnet openssl wget gnupg ca-certificates
+    bash vim unzip telnet openssl wget gnupg ca-certificates
 
 ARG version
 
@@ -50,23 +50,24 @@ RUN chown -R ${uid}:${gid} ${ROCKETMQ_HOME}
 EXPOSE 9876 8080 8081 7001 2023
 
 RUN wget https://repo1.maven.org/maven2/org/jacoco/jacoco/0.8.8/jacoco-0.8.8.zip -O jacoco-0.8.8.zip && \
-unzip jacoco-0.8.8.zip -d jacoco
+    unzip jacoco-0.8.8.zip -d jacoco
 
 ENV JAVA_OPT="-javaagent:${ROCKETMQ_HOME}/jacoco/lib/jacocoagent.jar=includes=*,output=tcpserver,port=2023,address=0.0.0.0"
 
 RUN mv ${ROCKETMQ_HOME}/bin/runserver-customize.sh ${ROCKETMQ_HOME}/bin/runserver.sh \
- && mv ${ROCKETMQ_HOME}/bin/tools-customize.sh ${ROCKETMQ_HOME}/bin/tools.sh \
- && chmod a+x ${ROCKETMQ_HOME}/bin/runserver.sh \
- && chmod a+x ${ROCKETMQ_HOME}/bin/mqadmin \
- && chmod a+x ${ROCKETMQ_HOME}/bin/mqnamesrv \
- && chmod a+x ${ROCKETMQ_HOME}/bin/mqproxy
+    && mv ${ROCKETMQ_HOME}/bin/tools-customize.sh ${ROCKETMQ_HOME}/bin/tools.sh \
+    && chmod a+x ${ROCKETMQ_HOME}/bin/runserver.sh \
+    && chmod a+x ${ROCKETMQ_HOME}/bin/mqadmin \
+    && chmod a+x ${ROCKETMQ_HOME}/bin/mqnamesrv \
+    && chmod a+x ${ROCKETMQ_HOME}/bin/mqproxy \
+    && chmod a+x ${ROCKETMQ_HOME}/bin/mqcontroller
 
 # Expose broker port
 EXPOSE 10909 10911 10912
 
 RUN mv ${ROCKETMQ_HOME}/bin/runbroker-customize.sh ${ROCKETMQ_HOME}/bin/runbroker.sh \
- && chmod a+x ${ROCKETMQ_HOME}/bin/runbroker.sh \
- && chmod a+x ${ROCKETMQ_HOME}/bin/mqbroker
+    && chmod a+x ${ROCKETMQ_HOME}/bin/runbroker.sh \
+    && chmod a+x ${ROCKETMQ_HOME}/bin/mqbroker
 
 # export Java options
 RUN export JAVA_OPT=" -Duser.home=/opt"

--- a/image-build-ci/scripts/runbroker-customize.sh
+++ b/image-build-ci/scripts/runbroker-customize.sh
@@ -52,7 +52,7 @@ export CLASSPATH=.:${BASE_DIR}/conf:${CLASSPATH}
 #===========================================================================================
 
 # Set default JVM memory options if not provided
-DEFAULT_HEAP_OPTS="-Xms1g -Xmx1g -Xmn512M -XX:MaxDirectMemorySize=1g"
+DEFAULT_HEAP_OPTS="-Xms2g -Xmx2g -Xmn1g -XX:MaxDirectMemorySize=1g"
 HEAP_OPTS=${HEAP_OPTS:-$DEFAULT_HEAP_OPTS}
 
 # Setting JAVA options

--- a/image-build-ci/scripts/runbroker-customize.sh
+++ b/image-build-ci/scripts/runbroker-customize.sh
@@ -57,8 +57,8 @@ HEAP_OPTS=${HEAP_OPTS:-$DEFAULT_HEAP_OPTS}
 
 # Setting JAVA options
 JAVA_OPT="${JAVA_OPT} -server ${HEAP_OPTS}"
-JAVA_OPT="${JAVA_OPT} -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30"
-JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/mq_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
+JAVA_OPT="${JAVA_OPT} -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -XX:SoftRefLRUPolicyMSPerMB=0 -XX:SurvivorRatio=8"
+JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/mq_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintAdaptiveSizePolicy"
 JAVA_OPT="${JAVA_OPT} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=30m"
 JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow"
 JAVA_OPT="${JAVA_OPT} -XX:+AlwaysPreTouch"

--- a/image-build-ci/scripts/runbroker-customize.sh
+++ b/image-build-ci/scripts/runbroker-customize.sh
@@ -50,92 +50,15 @@ export CLASSPATH=.:${BASE_DIR}/conf:${CLASSPATH}
 #===========================================================================================
 # JVM Configuration
 #===========================================================================================
-calculate_heap_sizes()
-{
-    case "`uname`" in
-        Linux)
-            system_memory_in_mb=`free -m| sed -n '2p' | awk '{print $2}'`
-            system_cpu_cores=`egrep -c 'processor([[:space:]]+):.*' /proc/cpuinfo`
-        ;;
-        FreeBSD)
-            system_memory_in_bytes=`sysctl hw.physmem | awk '{print $2}'`
-            system_memory_in_mb=`expr $system_memory_in_bytes / 1024 / 1024`
-            system_cpu_cores=`sysctl hw.ncpu | awk '{print $2}'`
-        ;;
-        SunOS)
-            system_memory_in_mb=`prtconf | awk '/Memory size:/ {print $3}'`
-            system_cpu_cores=`psrinfo | wc -l`
-        ;;
-        Darwin)
-            system_memory_in_bytes=`sysctl hw.memsize | awk '{print $2}'`
-            system_memory_in_mb=`expr $system_memory_in_bytes / 1024 / 1024`
-            system_cpu_cores=`sysctl hw.ncpu | awk '{print $2}'`
-        ;;
-        *)
-            # assume reasonable defaults for e.g. a modern desktop or
-            # cheap server
-            system_memory_in_mb="2048"
-            system_cpu_cores="2"
-        ;;
-    esac
 
-    # some systems like the raspberry pi don't report cores, use at least 1
-    if [ "$system_cpu_cores" -lt "1" ]
-    then
-        system_cpu_cores="1"
-    fi
+# Set default JVM memory options if not provided
+DEFAULT_HEAP_OPTS="-Xms1g -Xmx1g -Xmn512M -XX:MaxDirectMemorySize=1g"
+HEAP_OPTS=${HEAP_OPTS:-$DEFAULT_HEAP_OPTS}
 
-    # set max heap size based on the following
-    # max(min(1/2 ram, 1024MB), min(1/4 ram, 8GB))
-    # calculate 1/2 ram and cap to 1024MB
-    # calculate 1/4 ram and cap to 8192MB
-    # pick the max
-    half_system_memory_in_mb=`expr $system_memory_in_mb / 2`
-    quarter_system_memory_in_mb=`expr $half_system_memory_in_mb / 2`
-    if [ "$half_system_memory_in_mb" -gt "1024" ]
-    then
-        half_system_memory_in_mb="1024"
-    fi
-    if [ "$quarter_system_memory_in_mb" -gt "8192" ]
-    then
-        quarter_system_memory_in_mb="8192"
-    fi
-    if [ "$half_system_memory_in_mb" -gt "$quarter_system_memory_in_mb" ]
-    then
-        max_heap_size_in_mb="$half_system_memory_in_mb"
-    else
-        max_heap_size_in_mb="$quarter_system_memory_in_mb"
-    fi
-    MAX_HEAP_SIZE="${max_heap_size_in_mb}M"
-
-    # Young gen: min(max_sensible_per_modern_cpu_core * num_cores, 1/4 * heap size)
-    max_sensible_yg_per_core_in_mb="100"
-    max_sensible_yg_in_mb=`expr $max_sensible_yg_per_core_in_mb "*" $system_cpu_cores`
-
-    desired_yg_in_mb=`expr $max_heap_size_in_mb / 4`
-
-    if [ "$desired_yg_in_mb" -gt "$max_sensible_yg_in_mb" ]
-    then
-        HEAP_NEWSIZE="${max_sensible_yg_in_mb}M"
-    else
-        HEAP_NEWSIZE="${desired_yg_in_mb}M"
-    fi
-}
-
-if [ -z "$BROKER_MEM" ]; then
-    # Dynamically calculate parameters, for reference.
-    calculate_heap_sizes
-    Xms=$MAX_HEAP_SIZE
-    Xmx=$MAX_HEAP_SIZE
-    Xmn=$HEAP_NEWSIZE
-    MaxDirectMemorySize=$MAX_HEAP_SIZE
-    JAVA_OPT="${JAVA_OPT} -server -Xms${Xms} -Xmx${Xmx} -Xmn${Xmn} -XX:MaxDirectMemorySize=${MaxDirectMemorySize}"
-else
-    JAVA_OPT="${JAVA_OPT} -server ${BROKER_MEM}"
-fi
-
-JAVA_OPT="${JAVA_OPT} -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -XX:SoftRefLRUPolicyMSPerMB=0 -XX:SurvivorRatio=8"
-JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/mq_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintAdaptiveSizePolicy"
+# Setting JAVA options
+JAVA_OPT="${JAVA_OPT} -server ${HEAP_OPTS}"
+JAVA_OPT="${JAVA_OPT} -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30"
+JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/mq_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
 JAVA_OPT="${JAVA_OPT} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=30m"
 JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow"
 JAVA_OPT="${JAVA_OPT} -XX:+AlwaysPreTouch"

--- a/image-build-ci/scripts/runbroker-customize.sh
+++ b/image-build-ci/scripts/runbroker-customize.sh
@@ -122,7 +122,7 @@ calculate_heap_sizes()
     fi
 }
 
-if [ -z "$jvmMemory" ]; then
+if [ -z "$BROKER_MEM" ]; then
     # Dynamically calculate parameters, for reference.
     calculate_heap_sizes
     Xms=$MAX_HEAP_SIZE
@@ -131,7 +131,7 @@ if [ -z "$jvmMemory" ]; then
     MaxDirectMemorySize=$MAX_HEAP_SIZE
     JAVA_OPT="${JAVA_OPT} -server -Xms${Xms} -Xmx${Xmx} -Xmn${Xmn} -XX:MaxDirectMemorySize=${MaxDirectMemorySize}"
 else
-    JAVA_OPT="${JAVA_OPT} -server ${jvmMemory}"
+    JAVA_OPT="${JAVA_OPT} -server ${BROKER_MEM}"
 fi
 
 JAVA_OPT="${JAVA_OPT} -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -XX:SoftRefLRUPolicyMSPerMB=0 -XX:SurvivorRatio=8"

--- a/image-build-ci/scripts/runbroker-customize.sh
+++ b/image-build-ci/scripts/runbroker-customize.sh
@@ -122,21 +122,23 @@ calculate_heap_sizes()
     fi
 }
 
-calculate_heap_sizes
+if [ -z "$jvmMemory" ]; then
+    # Dynamically calculate parameters, for reference.
+    calculate_heap_sizes
+    Xms=$MAX_HEAP_SIZE
+    Xmx=$MAX_HEAP_SIZE
+    Xmn=$HEAP_NEWSIZE
+    MaxDirectMemorySize=$MAX_HEAP_SIZE
+    JAVA_OPT="${JAVA_OPT} -server -Xms${Xms} -Xmx${Xmx} -Xmn${Xmn} -XX:MaxDirectMemorySize=${MaxDirectMemorySize}"
+else
+    JAVA_OPT="${JAVA_OPT} -server ${jvmMemory}"
+fi
 
-# Dynamically calculate parameters, for reference.
-Xms=$MAX_HEAP_SIZE
-Xmx=$MAX_HEAP_SIZE
-Xmn=$HEAP_NEWSIZE
-MaxDirectMemorySize=$MAX_HEAP_SIZE
-# Set for `JAVA_OPT`.
-JAVA_OPT="${JAVA_OPT} -server -Xms${Xms} -Xmx${Xmx} -Xmn${Xmn}"
 JAVA_OPT="${JAVA_OPT} -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -XX:SoftRefLRUPolicyMSPerMB=0 -XX:SurvivorRatio=8"
 JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/mq_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintAdaptiveSizePolicy"
 JAVA_OPT="${JAVA_OPT} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=30m"
 JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow"
 JAVA_OPT="${JAVA_OPT} -XX:+AlwaysPreTouch"
-JAVA_OPT="${JAVA_OPT} -XX:MaxDirectMemorySize=${MaxDirectMemorySize}"
 JAVA_OPT="${JAVA_OPT} -XX:-UseLargePages -XX:-UseBiasedLocking"
 JAVA_OPT="${JAVA_OPT} -Djava.ext.dirs=${JAVA_HOME}/jre/lib/ext:${BASE_DIR}/lib"
 #JAVA_OPT="${JAVA_OPT} -Xdebug -Xrunjdwp:transport=dt_socket,address=9555,server=y,suspend=n"

--- a/image-build-ci/scripts/runserver-customize.sh
+++ b/image-build-ci/scripts/runserver-customize.sh
@@ -50,86 +50,11 @@ export CLASSPATH=.:${BASE_DIR}/conf:${CLASSPATH}
 #===========================================================================================
 # JVM Configuration
 #===========================================================================================
-calculate_heap_sizes()
-{
-    case "`uname`" in
-        Linux)
-            system_memory_in_mb=`free -m| sed -n '2p' | awk '{print $2}'`
-            system_cpu_cores=`egrep -c 'processor([[:space:]]+):.*' /proc/cpuinfo`
-        ;;
-        FreeBSD)
-            system_memory_in_bytes=`sysctl hw.physmem | awk '{print $2}'`
-            system_memory_in_mb=`expr $system_memory_in_bytes / 1024 / 1024`
-            system_cpu_cores=`sysctl hw.ncpu | awk '{print $2}'`
-        ;;
-        SunOS)
-            system_memory_in_mb=`prtconf | awk '/Memory size:/ {print $3}'`
-            system_cpu_cores=`psrinfo | wc -l`
-        ;;
-        Darwin)
-            system_memory_in_bytes=`sysctl hw.memsize | awk '{print $2}'`
-            system_memory_in_mb=`expr $system_memory_in_bytes / 1024 / 1024`
-            system_cpu_cores=`sysctl hw.ncpu | awk '{print $2}'`
-        ;;
-        *)
-            # assume reasonable defaults for e.g. a modern desktop or
-            # cheap server
-            system_memory_in_mb="2048"
-            system_cpu_cores="2"
-        ;;
-    esac
-
-    # some systems like the raspberry pi don't report cores, use at least 1
-    if [ "$system_cpu_cores" -lt "1" ]
-    then
-        system_cpu_cores="1"
-    fi
-
-    # set max heap size based on the following
-    # max(min(1/2 ram, 1024MB), min(1/4 ram, 8GB))
-    # calculate 1/2 ram and cap to 1024MB
-    # calculate 1/4 ram and cap to 8192MB
-    # pick the max
-    half_system_memory_in_mb=`expr $system_memory_in_mb / 2`
-    quarter_system_memory_in_mb=`expr $half_system_memory_in_mb / 2`
-    if [ "$half_system_memory_in_mb" -gt "1024" ]
-    then
-        half_system_memory_in_mb="1024"
-    fi
-    if [ "$quarter_system_memory_in_mb" -gt "8192" ]
-    then
-        quarter_system_memory_in_mb="8192"
-    fi
-    if [ "$half_system_memory_in_mb" -gt "$quarter_system_memory_in_mb" ]
-    then
-        max_heap_size_in_mb="$half_system_memory_in_mb"
-    else
-        max_heap_size_in_mb="$quarter_system_memory_in_mb"
-    fi
-    MAX_HEAP_SIZE="${max_heap_size_in_mb}M"
-
-    # Young gen: min(max_sensible_per_modern_cpu_core * num_cores, 1/4 * heap size)
-    max_sensible_yg_per_core_in_mb="100"
-    max_sensible_yg_in_mb=`expr $max_sensible_yg_per_core_in_mb "*" $system_cpu_cores`
-
-    desired_yg_in_mb=`expr $max_heap_size_in_mb / 4`
-
-    if [ "$desired_yg_in_mb" -gt "$max_sensible_yg_in_mb" ]
-    then
-        HEAP_NEWSIZE="${max_sensible_yg_in_mb}M"
-    else
-        HEAP_NEWSIZE="${desired_yg_in_mb}M"
-    fi
-}
-
-if [ -z "$NAMESRV_MEM" ]; then
-    # Dynamically calculate parameters.
-    calculate_heap_sizes
-    NAMESRV_MEM="-Xms${MAX_HEAP_SIZE} -Xmx${MAX_HEAP_SIZE} -Xmn${HEAP_NEWSIZE}"
-fi
+DEFAULT_HEAP_OPTS="-Xms1g -Xmx1g -Xmn512M"
+HEAP_OPTS=${HEAP_OPTS:-$DEFAULT_HEAP_OPTS}
 
 # Set for `JAVA_OPT`.
-JAVA_OPT="${JAVA_OPT} -server ${NAMESRV_MEM}"
+JAVA_OPT="${JAVA_OPT} -server ${HEAP_OPTS}"
 JAVA_OPT="${JAVA_OPT} -XX:+UseConcMarkSweepGC -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8  -XX:-UseParNewGC"
 JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/rmq_srv_gc.log -XX:+PrintGCDetails"
 JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow"

--- a/image-build-ci/scripts/runserver-customize.sh
+++ b/image-build-ci/scripts/runserver-customize.sh
@@ -122,14 +122,14 @@ calculate_heap_sizes()
     fi
 }
 
-if [ -z "$BROKER_MEM" ]; then
+if [ -z "$NAMESRV_MEM" ]; then
     # Dynamically calculate parameters.
     calculate_heap_sizes
-    BROKER_MEM="-Xms${MAX_HEAP_SIZE} -Xmx${MAX_HEAP_SIZE} -Xmn${HEAP_NEWSIZE}"
+    NAMESRV_MEM="-Xms${MAX_HEAP_SIZE} -Xmx${MAX_HEAP_SIZE} -Xmn${HEAP_NEWSIZE}"
 fi
 
 # Set for `JAVA_OPT`.
-JAVA_OPT="${JAVA_OPT} -server ${BROKER_MEM}"
+JAVA_OPT="${JAVA_OPT} -server ${NAMESRV_MEM}"
 JAVA_OPT="${JAVA_OPT} -XX:+UseConcMarkSweepGC -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8  -XX:-UseParNewGC"
 JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/rmq_srv_gc.log -XX:+PrintGCDetails"
 JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow"

--- a/image-build-ci/scripts/runserver-customize.sh
+++ b/image-build-ci/scripts/runserver-customize.sh
@@ -122,14 +122,14 @@ calculate_heap_sizes()
     fi
 }
 
-calculate_heap_sizes
+if [ -z "$jvmMemory" ]; then
+    # Dynamically calculate parameters.
+    calculate_heap_sizes
+    jvmMemory="-Xms${MAX_HEAP_SIZE} -Xmx${MAX_HEAP_SIZE} -Xmn${HEAP_NEWSIZE}"
+fi
 
-# Dynamically calculate parameters, for reference.
-Xms=$MAX_HEAP_SIZE
-Xmx=$MAX_HEAP_SIZE
-Xmn=$HEAP_NEWSIZE
 # Set for `JAVA_OPT`.
-JAVA_OPT="${JAVA_OPT} -server -Xms${Xms} -Xmx${Xmx} -Xmn${Xmn}"
+JAVA_OPT="${JAVA_OPT} -server ${jvmMemory}"
 JAVA_OPT="${JAVA_OPT} -XX:+UseConcMarkSweepGC -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8  -XX:-UseParNewGC"
 JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/rmq_srv_gc.log -XX:+PrintGCDetails"
 JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow"

--- a/image-build-ci/scripts/runserver-customize.sh
+++ b/image-build-ci/scripts/runserver-customize.sh
@@ -122,14 +122,14 @@ calculate_heap_sizes()
     fi
 }
 
-if [ -z "$jvmMemory" ]; then
+if [ -z "$BROKER_MEM" ]; then
     # Dynamically calculate parameters.
     calculate_heap_sizes
-    jvmMemory="-Xms${MAX_HEAP_SIZE} -Xmx${MAX_HEAP_SIZE} -Xmn${HEAP_NEWSIZE}"
+    BROKER_MEM="-Xms${MAX_HEAP_SIZE} -Xmx${MAX_HEAP_SIZE} -Xmn${HEAP_NEWSIZE}"
 fi
 
 # Set for `JAVA_OPT`.
-JAVA_OPT="${JAVA_OPT} -server ${jvmMemory}"
+JAVA_OPT="${JAVA_OPT} -server ${BROKER_MEM}"
 JAVA_OPT="${JAVA_OPT} -XX:+UseConcMarkSweepGC -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8  -XX:-UseParNewGC"
 JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/rmq_srv_gc.log -XX:+PrintGCDetails"
 JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow"

--- a/image-build/scripts/runbroker-customize.sh
+++ b/image-build/scripts/runbroker-customize.sh
@@ -52,7 +52,7 @@ export CLASSPATH=.:${BASE_DIR}/conf:${CLASSPATH}
 #===========================================================================================
 
 # Set default JVM memory options if not provided
-DEFAULT_HEAP_OPTS="-Xms1g -Xmx1g -Xmn512M -XX:MaxDirectMemorySize=1g"
+DEFAULT_HEAP_OPTS="-Xms2g -Xmx2g -Xmn1g -XX:MaxDirectMemorySize=1g"
 HEAP_OPTS=${HEAP_OPTS:-$DEFAULT_HEAP_OPTS}
 
 # Setting JAVA options

--- a/image-build/scripts/runbroker-customize.sh
+++ b/image-build/scripts/runbroker-customize.sh
@@ -134,13 +134,6 @@ else
     JAVA_OPT="${JAVA_OPT} -server ${BROKER_MEM}"
 fi
 
-# Dynamically calculate parameters, for reference.
-Xms=$MAX_HEAP_SIZE
-Xmx=$MAX_HEAP_SIZE
-Xmn=$HEAP_NEWSIZE
-MaxDirectMemorySize=$MAX_HEAP_SIZE
-# Set for `JAVA_OPT`.
-JAVA_OPT="${JAVA_OPT} -server -Xms${Xms} -Xmx${Xmx} -Xmn${Xmn}"
 JAVA_OPT="${JAVA_OPT} -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -XX:SoftRefLRUPolicyMSPerMB=0 -XX:SurvivorRatio=8"
 JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/mq_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintAdaptiveSizePolicy"
 JAVA_OPT="${JAVA_OPT} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=30m"

--- a/image-build/scripts/runbroker-customize.sh
+++ b/image-build/scripts/runbroker-customize.sh
@@ -50,90 +50,13 @@ export CLASSPATH=.:${BASE_DIR}/conf:${CLASSPATH}
 #===========================================================================================
 # JVM Configuration
 #===========================================================================================
-calculate_heap_sizes()
-{
-    case "`uname`" in
-        Linux)
-            system_memory_in_mb=`free -m| sed -n '2p' | awk '{print $2}'`
-            system_cpu_cores=`egrep -c 'processor([[:space:]]+):.*' /proc/cpuinfo`
-        ;;
-        FreeBSD)
-            system_memory_in_bytes=`sysctl hw.physmem | awk '{print $2}'`
-            system_memory_in_mb=`expr $system_memory_in_bytes / 1024 / 1024`
-            system_cpu_cores=`sysctl hw.ncpu | awk '{print $2}'`
-        ;;
-        SunOS)
-            system_memory_in_mb=`prtconf | awk '/Memory size:/ {print $3}'`
-            system_cpu_cores=`psrinfo | wc -l`
-        ;;
-        Darwin)
-            system_memory_in_bytes=`sysctl hw.memsize | awk '{print $2}'`
-            system_memory_in_mb=`expr $system_memory_in_bytes / 1024 / 1024`
-            system_cpu_cores=`sysctl hw.ncpu | awk '{print $2}'`
-        ;;
-        *)
-            # assume reasonable defaults for e.g. a modern desktop or
-            # cheap server
-            system_memory_in_mb="2048"
-            system_cpu_cores="2"
-        ;;
-    esac
 
-    # some systems like the raspberry pi don't report cores, use at least 1
-    if [ "$system_cpu_cores" -lt "1" ]
-    then
-        system_cpu_cores="1"
-    fi
+# Set default JVM memory options if not provided
+DEFAULT_HEAP_OPTS="-Xms1g -Xmx1g -Xmn512M -XX:MaxDirectMemorySize=1g"
+HEAP_OPTS=${HEAP_OPTS:-$DEFAULT_HEAP_OPTS}
 
-    # set max heap size based on the following
-    # max(min(1/2 ram, 1024MB), min(1/4 ram, 8GB))
-    # calculate 1/2 ram and cap to 1024MB
-    # calculate 1/4 ram and cap to 8192MB
-    # pick the max
-    half_system_memory_in_mb=`expr $system_memory_in_mb / 2`
-    quarter_system_memory_in_mb=`expr $half_system_memory_in_mb / 2`
-    if [ "$half_system_memory_in_mb" -gt "1024" ]
-    then
-        half_system_memory_in_mb="1024"
-    fi
-    if [ "$quarter_system_memory_in_mb" -gt "8192" ]
-    then
-        quarter_system_memory_in_mb="8192"
-    fi
-    if [ "$half_system_memory_in_mb" -gt "$quarter_system_memory_in_mb" ]
-    then
-        max_heap_size_in_mb="$half_system_memory_in_mb"
-    else
-        max_heap_size_in_mb="$quarter_system_memory_in_mb"
-    fi
-    MAX_HEAP_SIZE="${max_heap_size_in_mb}M"
-
-    # Young gen: min(max_sensible_per_modern_cpu_core * num_cores, 1/4 * heap size)
-    max_sensible_yg_per_core_in_mb="100"
-    max_sensible_yg_in_mb=`expr $max_sensible_yg_per_core_in_mb "*" $system_cpu_cores`
-
-    desired_yg_in_mb=`expr $max_heap_size_in_mb / 4`
-
-    if [ "$desired_yg_in_mb" -gt "$max_sensible_yg_in_mb" ]
-    then
-        HEAP_NEWSIZE="${max_sensible_yg_in_mb}M"
-    else
-        HEAP_NEWSIZE="${desired_yg_in_mb}M"
-    fi
-}
-
-if [ -z "$BROKER_MEM" ]; then
-    # Dynamically calculate parameters, for reference.
-    calculate_heap_sizes
-    Xms=$MAX_HEAP_SIZE
-    Xmx=$MAX_HEAP_SIZE
-    Xmn=$HEAP_NEWSIZE
-    MaxDirectMemorySize=$MAX_HEAP_SIZE
-    JAVA_OPT="${JAVA_OPT} -server -Xms${Xms} -Xmx${Xmx} -Xmn${Xmn} -XX:MaxDirectMemorySize=${MaxDirectMemorySize}"
-else
-    JAVA_OPT="${JAVA_OPT} -server ${BROKER_MEM}"
-fi
-
+# Setting JAVA options
+JAVA_OPT="${JAVA_OPT} -server ${HEAP_OPTS}"
 JAVA_OPT="${JAVA_OPT} -XX:+UseG1GC -XX:G1HeapRegionSize=16m -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -XX:SoftRefLRUPolicyMSPerMB=0 -XX:SurvivorRatio=8"
 JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/mq_gc_%p.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintGCApplicationStoppedTime -XX:+PrintAdaptiveSizePolicy"
 JAVA_OPT="${JAVA_OPT} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=30m"

--- a/image-build/scripts/runbroker-customize.sh
+++ b/image-build/scripts/runbroker-customize.sh
@@ -122,7 +122,17 @@ calculate_heap_sizes()
     fi
 }
 
-calculate_heap_sizes
+if [ -z "$BROKER_MEM" ]; then
+    # Dynamically calculate parameters, for reference.
+    calculate_heap_sizes
+    Xms=$MAX_HEAP_SIZE
+    Xmx=$MAX_HEAP_SIZE
+    Xmn=$HEAP_NEWSIZE
+    MaxDirectMemorySize=$MAX_HEAP_SIZE
+    JAVA_OPT="${JAVA_OPT} -server -Xms${Xms} -Xmx${Xmx} -Xmn${Xmn} -XX:MaxDirectMemorySize=${MaxDirectMemorySize}"
+else
+    JAVA_OPT="${JAVA_OPT} -server ${BROKER_MEM}"
+fi
 
 # Dynamically calculate parameters, for reference.
 Xms=$MAX_HEAP_SIZE
@@ -136,7 +146,6 @@ JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/mq_gc_%p.log -XX:+PrintGCDeta
 JAVA_OPT="${JAVA_OPT} -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=30m"
 JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow"
 JAVA_OPT="${JAVA_OPT} -XX:+AlwaysPreTouch"
-JAVA_OPT="${JAVA_OPT} -XX:MaxDirectMemorySize=${MaxDirectMemorySize}"
 JAVA_OPT="${JAVA_OPT} -XX:-UseLargePages -XX:-UseBiasedLocking"
 JAVA_OPT="${JAVA_OPT} -Djava.ext.dirs=${JAVA_HOME}/jre/lib/ext:${BASE_DIR}/lib"
 #JAVA_OPT="${JAVA_OPT} -Xdebug -Xrunjdwp:transport=dt_socket,address=9555,server=y,suspend=n"

--- a/image-build/scripts/runserver-customize.sh
+++ b/image-build/scripts/runserver-customize.sh
@@ -55,7 +55,6 @@ HEAP_OPTS=${HEAP_OPTS:-$DEFAULT_HEAP_OPTS}
 
 # Set for `JAVA_OPT`.
 JAVA_OPT="${JAVA_OPT} -server ${HEAP_OPTS}"
-JAVA_OPT="${JAVA_OPT} -server ${NAMESRV_MEM}"
 JAVA_OPT="${JAVA_OPT} -XX:+UseConcMarkSweepGC -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8  -XX:-UseParNewGC"
 JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/rmq_srv_gc.log -XX:+PrintGCDetails"
 JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow"

--- a/image-build/scripts/runserver-customize.sh
+++ b/image-build/scripts/runserver-customize.sh
@@ -50,89 +50,11 @@ export CLASSPATH=.:${BASE_DIR}/conf:${CLASSPATH}
 #===========================================================================================
 # JVM Configuration
 #===========================================================================================
-calculate_heap_sizes()
-{
-    case "`uname`" in
-        Linux)
-            system_memory_in_mb=`free -m| sed -n '2p' | awk '{print $2}'`
-            system_cpu_cores=`egrep -c 'processor([[:space:]]+):.*' /proc/cpuinfo`
-        ;;
-        FreeBSD)
-            system_memory_in_bytes=`sysctl hw.physmem | awk '{print $2}'`
-            system_memory_in_mb=`expr $system_memory_in_bytes / 1024 / 1024`
-            system_cpu_cores=`sysctl hw.ncpu | awk '{print $2}'`
-        ;;
-        SunOS)
-            system_memory_in_mb=`prtconf | awk '/Memory size:/ {print $3}'`
-            system_cpu_cores=`psrinfo | wc -l`
-        ;;
-        Darwin)
-            system_memory_in_bytes=`sysctl hw.memsize | awk '{print $2}'`
-            system_memory_in_mb=`expr $system_memory_in_bytes / 1024 / 1024`
-            system_cpu_cores=`sysctl hw.ncpu | awk '{print $2}'`
-        ;;
-        *)
-            # assume reasonable defaults for e.g. a modern desktop or
-            # cheap server
-            system_memory_in_mb="2048"
-            system_cpu_cores="2"
-        ;;
-    esac
+DEFAULT_HEAP_OPTS="-Xms1g -Xmx1g -Xmn512M"
+HEAP_OPTS=${HEAP_OPTS:-$DEFAULT_HEAP_OPTS}
 
-    # some systems like the raspberry pi don't report cores, use at least 1
-    if [ "$system_cpu_cores" -lt "1" ]
-    then
-        system_cpu_cores="1"
-    fi
-
-    # set max heap size based on the following
-    # max(min(1/2 ram, 1024MB), min(1/4 ram, 8GB))
-    # calculate 1/2 ram and cap to 1024MB
-    # calculate 1/4 ram and cap to 8192MB
-    # pick the max
-    half_system_memory_in_mb=`expr $system_memory_in_mb / 2`
-    quarter_system_memory_in_mb=`expr $half_system_memory_in_mb / 2`
-    if [ "$half_system_memory_in_mb" -gt "1024" ]
-    then
-        half_system_memory_in_mb="1024"
-    fi
-    if [ "$quarter_system_memory_in_mb" -gt "8192" ]
-    then
-        quarter_system_memory_in_mb="8192"
-    fi
-    if [ "$half_system_memory_in_mb" -gt "$quarter_system_memory_in_mb" ]
-    then
-        max_heap_size_in_mb="$half_system_memory_in_mb"
-    else
-        max_heap_size_in_mb="$quarter_system_memory_in_mb"
-    fi
-    MAX_HEAP_SIZE="${max_heap_size_in_mb}M"
-
-    # Young gen: min(max_sensible_per_modern_cpu_core * num_cores, 1/4 * heap size)
-    max_sensible_yg_per_core_in_mb="100"
-    max_sensible_yg_in_mb=`expr $max_sensible_yg_per_core_in_mb "*" $system_cpu_cores`
-
-    desired_yg_in_mb=`expr $max_heap_size_in_mb / 4`
-
-    if [ "$desired_yg_in_mb" -gt "$max_sensible_yg_in_mb" ]
-    then
-        HEAP_NEWSIZE="${max_sensible_yg_in_mb}M"
-    else
-        HEAP_NEWSIZE="${desired_yg_in_mb}M"
-    fi
-}
-
-if [ -z "$NAMESRV_MEM" ]; then
-    # Dynamically calculate parameters.
-    calculate_heap_sizes
-    NAMESRV_MEM="-Xms${MAX_HEAP_SIZE} -Xmx${MAX_HEAP_SIZE} -Xmn${HEAP_NEWSIZE}"
-fi
-
-# Dynamically calculate parameters, for reference.
-Xms=$MAX_HEAP_SIZE
-Xmx=$MAX_HEAP_SIZE
-Xmn=$HEAP_NEWSIZE
 # Set for `JAVA_OPT`.
+JAVA_OPT="${JAVA_OPT} -server ${HEAP_OPTS}"
 JAVA_OPT="${JAVA_OPT} -server ${NAMESRV_MEM}"
 JAVA_OPT="${JAVA_OPT} -XX:+UseConcMarkSweepGC -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8  -XX:-UseParNewGC"
 JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/rmq_srv_gc.log -XX:+PrintGCDetails"

--- a/image-build/scripts/runserver-customize.sh
+++ b/image-build/scripts/runserver-customize.sh
@@ -122,14 +122,18 @@ calculate_heap_sizes()
     fi
 }
 
-calculate_heap_sizes
+if [ -z "$NAMESRV_MEM" ]; then
+    # Dynamically calculate parameters.
+    calculate_heap_sizes
+    NAMESRV_MEM="-Xms${MAX_HEAP_SIZE} -Xmx${MAX_HEAP_SIZE} -Xmn${HEAP_NEWSIZE}"
+fi
 
 # Dynamically calculate parameters, for reference.
 Xms=$MAX_HEAP_SIZE
 Xmx=$MAX_HEAP_SIZE
 Xmn=$HEAP_NEWSIZE
 # Set for `JAVA_OPT`.
-JAVA_OPT="${JAVA_OPT} -server -Xms${Xms} -Xmx${Xmx} -Xmn${Xmn}"
+JAVA_OPT="${JAVA_OPT} -server ${NAMESRV_MEM}"
 JAVA_OPT="${JAVA_OPT} -XX:+UseConcMarkSweepGC -XX:+UseCMSCompactAtFullCollection -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled -XX:SoftRefLRUPolicyMSPerMB=0 -XX:+CMSClassUnloadingEnabled -XX:SurvivorRatio=8  -XX:-UseParNewGC"
 JAVA_OPT="${JAVA_OPT} -verbose:gc -Xloggc:/dev/shm/rmq_srv_gc.log -XX:+PrintGCDetails"
 JAVA_OPT="${JAVA_OPT} -XX:-OmitStackTraceInFastThrow"

--- a/rocketmq-k8s-helm/templates/broker/statefulset.yaml
+++ b/rocketmq-k8s-helm/templates/broker/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: HEAP_OPT
+            - name: HEAP_OPTS
               value: {{ .Values.broker.jvmMemory }}
             - name: NAMESRV_ADDR
               value: {{ include "rocketmq-nameserver.fullname" . }}:9876

--- a/rocketmq-k8s-helm/templates/broker/statefulset.yaml
+++ b/rocketmq-k8s-helm/templates/broker/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: BROKER_MEM
+            - name: HEAP_OPT
               value: {{ .Values.broker.jvmMemory }}
             - name: NAMESRV_ADDR
               value: {{ include "rocketmq-nameserver.fullname" . }}:9876

--- a/rocketmq-k8s-helm/templates/controller/statefulset.yaml
+++ b/rocketmq-k8s-helm/templates/controller/statefulset.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       containers: 
       - name: controller
-        image: "{{ .Values.controller.image.registry }}/{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
+        image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
         env: 
         - name: NODE_ROLE

--- a/rocketmq-k8s-helm/values.yaml
+++ b/rocketmq-k8s-helm/values.yaml
@@ -206,7 +206,6 @@ controller:
   fullnameOverride: ""
   replicas: 3
   image:
-    registry: docker.io
     repository: "apache/rocketmq"
     tag: "latest"
     pullPolicy: IfNotPresent

--- a/rocketmq-k8s-helm/values.yaml
+++ b/rocketmq-k8s-helm/values.yaml
@@ -188,7 +188,7 @@ broker:
   service:
     port: 10911
 
-  jvmMemory: " -Xms4g -Xmx4g -Xmn2g -XX:MaxDirectMemorySize=8g "
+  jvmMemory: " -Xms2g -Xmx2g -Xmn1g -XX:MaxDirectMemorySize=4g "
   resources:
     limits:
       cpu: 2

--- a/rocketmq-k8s-helm/values.yaml
+++ b/rocketmq-k8s-helm/values.yaml
@@ -188,14 +188,14 @@ broker:
   service:
     port: 10911
 
-  jvmMemory: " -Xms2g -Xmx2g -Xmn1g -XX:MaxDirectMemorySize=4g "
+  jvmMemory: " -Xms4g -Xmx4g -Xmn2g -XX:MaxDirectMemorySize=8g "
   resources:
     limits:
       cpu: 2
-      memory: 4Gi
+      memory: 6Gi
     requests:
       cpu: 2
-      memory: 4Gi
+      memory: 6Gi
 
   nodeSelector: { }
 


### PR DESCRIPTION
- Fixes [#94](https://github.com/apache/rocketmq-docker/issues/94)
- Removed the automatic heap size calculation code and set default values for Java heap memory.
- Added support for users to customize JVM options (-Xms, -Xmx, -Xmn) by providing the `HEAP_OPTS` environment variable.
- Adjusted Helm Chart resource limits to prevent OOM errors when running RocketMQ containers.