### PR TITLE
fix: When the pod restarts, the broker data is lost.

### DIFF
--- a/rocketmq-k8s-helm/templates/broker/statefulset.yaml
+++ b/rocketmq-k8s-helm/templates/broker/statefulset.yaml
@@ -78,7 +78,7 @@ spec:
             - mountPath: /home/rocketmq/logs
               name: broker-storage
               subPath: home/rocketmq/rocketmq-broker
-            - mountPath: /root/store
+            - mountPath: /home/rocketmq/store
               name: broker-storage
               subPath: store/rocketmq-broker
       {{- with .Values.broker.nodeSelector }}


### PR DESCRIPTION
The persistent data dir of the broker is not correctly mounted to the correct directory in the container, resulting in the loss of broker data after the pod is restarted.