### PR TITLE
[ISSUE #116] add workflow for multi-ach Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,81 @@
+name: docker-publish
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  REGISTRY: docker.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: apache/rocketmq
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get the latest release version with GitHub Script
+        id: get_release
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: latestRelease } = await github.rest.repos.getLatestRelease({
+              owner: 'apache',
+              repo: 'rocketmq'
+            });
+            core.setOutput('version_on_github', latestRelease.tag_name.replaceAll("rocketmq-all-", ""));
+
+      - name: Output the latest release version
+        run: echo "The latest release version is ${{ steps.get_release.outputs.version_on_github }}"
+
+      - name: Check if Docker image exists
+        id: check_image
+        run: |
+          TAG="${{ steps.get_release.outputs.version_on_github }}"
+          EXISTS=$(curl -s -o /dev/null -w "%{http_code}" "https://hub.docker.com/v2/repositories/${{ env.IMAGE_NAME }}/tags/$TAG/")
+          if [ "$EXISTS" -eq "200" ]; then
+            echo "exists=true" >> $GITHUB_ENV
+          else
+            echo "exists=false" >> $GITHUB_ENV
+          fi
+
+      - name: Set up Docker Buildx
+        if: env.exists == 'false'
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        #if: env.exists == 'false' && github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        if: env.exists == 'false'
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{defaultContext}}:image-build"
+          file: Dockerfile-ubuntu
+          platforms: linux/amd64,linux/arm64
+          pull: true
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ steps.get_release.outputs.version_on_github }}
+          build-args: version=${{ steps.get_release.outputs.version_on_github }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
add a GitHub workflow for building and pushing Docker image for Apache RocketMQ, with 2 platforms (`linux/amd64` and `linux/arm64`).

Resolves #116 , resolves #98 