### PR TITLE
Fix the broker-server mount path error, which causes data to fail to persist

### DIFF
--- a/rocketmq-k8s-helm/templates/broker/statefulset.yaml
+++ b/rocketmq-k8s-helm/templates/broker/statefulset.yaml
@@ -78,13 +78,15 @@ spec:
             - mountPath: /home/rocketmq/logs
               name: broker-storage
               subPath: home/rocketmq/rocketmq-broker
-            - mountPath: /root/store
+            - mountPath: /home/rocketmq//store
               name: broker-storage
               subPath: store/rocketmq-broker
       {{- with .Values.broker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      securityContext:
+        fsGroup: 3000
       volumes:
         - name: broker-config
           configMap:

--- a/rocketmq-k8s-helm/templates/broker/statefulset.yaml
+++ b/rocketmq-k8s-helm/templates/broker/statefulset.yaml
@@ -78,7 +78,7 @@ spec:
             - mountPath: /home/rocketmq/logs
               name: broker-storage
               subPath: home/rocketmq/rocketmq-broker
-            - mountPath: /home/rocketmq//store
+            - mountPath: /home/rocketmq/store
               name: broker-storage
               subPath: store/rocketmq-broker
       {{- with .Values.broker.nodeSelector }}


### PR DESCRIPTION
#119 Fix the broker-server mount path error, which causes data to fail to persist.
Configure a Security Context for a Pod 。